### PR TITLE
Add ONNX export script

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ The script expects a CSV file with a `text` column and a `label` column
 (alternatively `generated` or `is_ai_generated`). The trained model and
 tokenizer will be saved to the directory specified by `--output-dir`.
 
+## Exporting the Model to ONNX
+
+After training you can export the model to ONNX format using `ml/export_to_onnx.py`.
+
+```bash
+python ml/export_to_onnx.py \
+  --model-dir ./ml_models/trained_model \
+  --output-path ./ml_models/model.onnx
+```
+
+This script loads the saved model and tokenizer, exports it using opset version 14, and verifies the resulting ONNX file.
+
+
 ## Team
 - Cheikh Ahmedou Enaha
 - Djilit Abdellahi

--- a/ml/export_to_onnx.py
+++ b/ml/export_to_onnx.py
@@ -1,0 +1,56 @@
+import argparse
+import torch
+import onnx
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+
+def export_model(model_dir: str, output_path: str, opset: int = 14, max_length: int = 256) -> None:
+    """Export a Hugging Face model to ONNX format and verify the result."""
+    print(f"Loading model from {model_dir}")
+    model = AutoModelForSequenceClassification.from_pretrained(model_dir)
+    tokenizer = AutoTokenizer.from_pretrained(model_dir)
+
+    model.eval()
+    dummy = tokenizer(
+        "Export to ONNX", return_tensors="pt", padding="max_length", truncation=True, max_length=max_length
+    )
+
+    input_ids = dummy["input_ids"]
+    attention_mask = dummy["attention_mask"]
+
+    print(f"Exporting model to {output_path}")
+    with torch.no_grad():
+        torch.onnx.export(
+            model,
+            (input_ids, attention_mask),
+            output_path,
+            input_names=["input_ids", "attention_mask"],
+            output_names=["logits"],
+            dynamic_axes={
+                "input_ids": {0: "batch_size", 1: "sequence_length"},
+                "attention_mask": {0: "batch_size", 1: "sequence_length"},
+                "logits": {0: "batch_size"},
+            },
+            opset_version=opset,
+        )
+
+    print("Verifying exported ONNX model")
+    onnx_model = onnx.load(output_path)
+    onnx.checker.check_model(onnx_model)
+    print("ONNX model verified successfully")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export a Hugging Face model to ONNX")
+    parser.add_argument("--model-dir", required=True, help="Path to the trained model directory")
+    parser.add_argument(
+        "--output-path", default="model.onnx", help="Where to save the exported ONNX model"
+    )
+    parser.add_argument("--opset-version", type=int, default=14, help="ONNX opset version")
+    args = parser.parse_args()
+
+    export_model(args.model_dir, args.output_path, args.opset_version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `ml/export_to_onnx.py` to export a saved HF model to ONNX
- document ONNX export usage in `README.md`

## Testing
- `python -m py_compile ml/export_to_onnx.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851978489408327bce2f9837722008e