### PR TITLE
Use saved tokenizer for inference

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import numpy as np
 import onnxruntime as ort
-import json
+from transformers import PreTrainedTokenizerFast
 import os
 
 # Initialize FastAPI app
@@ -40,75 +40,7 @@ class PredictionResponse(BaseModel):
 # Global variables
 ort_session = None
 tokenizer_vocab = None
-
-# Simple tokenizer implementation
-class SimpleTokenizer:
-    def __init__(self, vocab_file):
-        self.vocab = {}
-        self.ids_to_tokens = {}
-        
-        # Load vocabulary from tokenizer.json
-        try:
-            with open(vocab_file, 'r', encoding='utf-8') as f:
-                tokenizer_data = json.load(f)
-                
-                # Extract vocabulary mapping
-                if 'model' in tokenizer_data and 'vocab' in tokenizer_data['model']:
-                    self.vocab = tokenizer_data['model']['vocab']
-                elif 'vocab' in tokenizer_data:
-                    self.vocab = tokenizer_data['vocab']
-                
-                # Create reverse mapping
-                self.ids_to_tokens = {v: k for k, v in self.vocab.items()}
-                
-                # Get special token ids
-                self.cls_token_id = tokenizer_data.get('cls_token_id', 101)
-                self.sep_token_id = tokenizer_data.get('sep_token_id', 102)
-                self.pad_token_id = tokenizer_data.get('pad_token_id', 0)
-                self.unk_token_id = tokenizer_data.get('unk_token_id', 100)
-                
-                print(f"Loaded vocabulary with {len(self.vocab)} tokens")
-        except Exception as e:
-            print(f"Error loading tokenizer vocabulary: {e}")
-            # Default special token IDs for DistilBERT
-            self.cls_token_id = 101
-            self.sep_token_id = 102
-            self.pad_token_id = 0
-            self.unk_token_id = 100
-    
-    def tokenize(self, text, max_length=256):
-        # Simple tokenization implementation
-        # In a real implementation, you'd need to handle subwords properly
-        words = text.lower().split()
-        tokens = []
-        
-        # Add CLS token
-        tokens.append(self.cls_token_id)
-        
-        # Process each word
-        for word in words:
-            if word in self.vocab:
-                tokens.append(self.vocab[word])
-            else:
-                # Handle unknown words
-                tokens.append(self.unk_token_id)
-        
-        # Add SEP token
-        tokens.append(self.sep_token_id)
-        
-        # Truncate or pad as needed
-        if len(tokens) > max_length:
-            tokens = tokens[:max_length-1] + [self.sep_token_id]
-        else:
-            tokens += [self.pad_token_id] * (max_length - len(tokens))
-        
-        # Create attention mask (1 for real tokens, 0 for padding)
-        attention_mask = [1 if t != self.pad_token_id else 0 for t in tokens]
-        
-        return {
-            "input_ids": np.array([tokens], dtype=np.int64),
-            "attention_mask": np.array([attention_mask], dtype=np.int64)
-        }
+MAX_LENGTH = 256
 
 # Load model on startup
 @app.on_event("startup")
@@ -122,7 +54,7 @@ async def load_model():
         
         # Initialize tokenizer
         if os.path.exists(TOKENIZER_PATH):
-            tokenizer_vocab = SimpleTokenizer(TOKENIZER_PATH)
+            tokenizer_vocab = PreTrainedTokenizerFast(tokenizer_file=TOKENIZER_PATH)
             print("Tokenizer loaded successfully")
         else:
             print(f"Warning: Tokenizer file not found at {TOKENIZER_PATH}")
@@ -149,8 +81,14 @@ async def predict(request: TextRequest):
         )
     
     try:
-        # Tokenize input text
-        inputs = tokenizer_vocab.tokenize(request.text)
+        # Tokenize input text using the same settings as training
+        inputs = tokenizer_vocab(
+            request.text,
+            return_tensors="np",
+            padding="max_length",
+            truncation=True,
+            max_length=MAX_LENGTH,
+        )
         
         # Get input names from model
         input_names = [x.name for x in ort_session.get_inputs()]


### PR DESCRIPTION
## Summary
- replace SimpleTokenizer with `PreTrainedTokenizerFast`
- load tokenizer.json directly using `transformers`
- remove manual tokenization logic and use the tokenizer the model was trained with

## Testing
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6852a89ff6348327b183f14d867c0684