### PR TITLE
Add image model training and API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ The script expects a CSV file with a `text` column and a `label` column
 (alternatively `generated` or `is_ai_generated`). The trained model and
 tokenizer will be saved to the directory specified by `--output-dir`.
 
+## Training the Image Model
+
+Use `ml/train_image_model.py` to train an AI-vs-real image classifier. The script
+expects a directory structured for `torchvision.datasets.ImageFolder` (e.g.
+`real/` and `ai/` subdirectories).
+
+```bash
+python ml/train_image_model.py \
+  --dataset-path path/to/images \
+  --output-dir ./ml_models/image_model
+```
+
 ## Exporting the Model to ONNX
 
 After training you can export the model to ONNX format using `ml/export_to_onnx.py`.
@@ -88,6 +100,29 @@ python ml/export_to_onnx.py \
 ```
 
 This script loads the saved model and tokenizer, exports it using opset version 14, and verifies the resulting ONNX file.
+
+### Exporting the Image Model
+
+After training an image model you can export it using `ml/export_image_to_onnx.py`.
+
+```bash
+python ml/export_image_to_onnx.py \
+  --weights ./ml_models/image_model/image_model.pth \
+  --output ./ml_models/image_model.onnx
+```
+
+## API Usage
+
+### `POST /predict-image`
+
+Send an image file using `multipart/form-data` or provide a base64 string using the `image_base64` form field.
+
+```bash
+curl -X POST http://localhost:8000/predict-image \
+  -F "file=@example.jpg"
+```
+
+The response contains the predicted label and confidence score.
 
 
 ## Team

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,10 +1,13 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, UploadFile, File, Form
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import numpy as np
 import onnxruntime as ort
 from transformers import PreTrainedTokenizerFast
 import os
+from PIL import Image
+import base64
+from io import BytesIO
 
 # Initialize FastAPI app
 app = FastAPI(
@@ -25,6 +28,7 @@ app.add_middleware(
 # Define paths to model and tokenizer files
 MODEL_PATH = "../ml_models/onnx/model.onnx"
 TOKENIZER_PATH = "../ml_models/tokenizer.json"
+IMAGE_MODEL_PATH = "../ml_models/onnx/image_model.onnx"
 
 # Request model
 class TextRequest(BaseModel):
@@ -37,15 +41,23 @@ class PredictionResponse(BaseModel):
     is_ai_generated: bool
     confidence: float
 
+
+class ImagePredictionResponse(BaseModel):
+    prediction: str
+    is_ai_generated: bool
+    confidence: float
+
 # Global variables
 ort_session = None
 tokenizer_vocab = None
+image_session = None
 MAX_LENGTH = 256
+IMAGE_SIZE = 224
 
 # Load model on startup
 @app.on_event("startup")
 async def load_model():
-    global ort_session, tokenizer_vocab
+    global ort_session, tokenizer_vocab, image_session
     
     try:
         print(f"Loading ONNX model from {MODEL_PATH}")
@@ -60,6 +72,13 @@ async def load_model():
             print(f"Warning: Tokenizer file not found at {TOKENIZER_PATH}")
         
         print("Model loaded successfully")
+        if os.path.exists(IMAGE_MODEL_PATH):
+            image_session = ort.InferenceSession(
+                IMAGE_MODEL_PATH, providers=["CPUExecutionProvider"]
+            )
+            print("Image model loaded successfully")
+        else:
+            print(f"Warning: Image model not found at {IMAGE_MODEL_PATH}")
     except Exception as e:
         print(f"Error loading model: {e}")
 
@@ -132,6 +151,53 @@ async def predict(request: TextRequest):
             detail=f"Error during prediction: {str(e)}"
         )
 
+
+@app.post("/predict-image", response_model=ImagePredictionResponse)
+async def predict_image(file: UploadFile = File(None), image_base64: str = Form(None)):
+    global image_session
+
+    if image_session is None:
+        raise HTTPException(status_code=503, detail="Image model not loaded")
+
+    if file is not None:
+        image_bytes = await file.read()
+    elif image_base64:
+        try:
+            image_bytes = base64.b64decode(image_base64)
+        except Exception:
+            raise HTTPException(status_code=400, detail="Invalid base64 data")
+    else:
+        raise HTTPException(status_code=400, detail="No image provided")
+
+    try:
+        img = Image.open(BytesIO(image_bytes)).convert("RGB")
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid image file")
+
+    img = img.resize((IMAGE_SIZE, IMAGE_SIZE))
+    arr = np.array(img).astype(np.float32) / 255.0
+    arr = (arr - np.array([0.485, 0.456, 0.406])) / np.array([0.229, 0.224, 0.225])
+    arr = np.transpose(arr, (2, 0, 1))
+    arr = np.expand_dims(arr, 0)
+
+    input_name = image_session.get_inputs()[0].name
+    outputs = image_session.run(None, {input_name: arr})
+    logits = outputs[0]
+
+    exp_logits = np.exp(logits - np.max(logits, axis=1, keepdims=True))
+    probabilities = exp_logits / np.sum(exp_logits, axis=1, keepdims=True)
+
+    prediction = int(np.argmax(probabilities, axis=1)[0])
+    confidence = float(probabilities[0][prediction])
+    is_ai = prediction == 1
+    label = "AI-generated" if is_ai else "Real"
+
+    return ImagePredictionResponse(
+        prediction=label,
+        is_ai_generated=is_ai,
+        confidence=confidence,
+    )
+
 # Health check endpoint
 @app.get("/health")
 async def health_check():
@@ -146,6 +212,7 @@ async def root():
         "message": "AI Text Detection API",
         "endpoints": {
             "/predict": "POST - Submit text for AI detection",
+            "/predict-image": "POST - Submit image for AI detection",
             "/health": "GET - Check API health"
         }
     }

--- a/ml/export_image_to_onnx.py
+++ b/ml/export_image_to_onnx.py
@@ -1,0 +1,39 @@
+import argparse
+import onnx
+import torch
+from torchvision import models
+
+
+def export_model(weights_path: str, output_path: str, img_size: int = 224, opset: int = 14) -> None:
+    """Load a PyTorch image model and export it to ONNX format."""
+    model = models.resnet18(weights=None)
+    model.fc = torch.nn.Linear(model.fc.in_features, 2)
+    state = torch.load(weights_path, map_location="cpu")
+    model.load_state_dict(state)
+    model.eval()
+
+    dummy = torch.randn(1, 3, img_size, img_size)
+    torch.onnx.export(
+        model,
+        dummy,
+        output_path,
+        input_names=["input"],
+        output_names=["logits"],
+        dynamic_axes={"input": {0: "batch_size"}, "logits": {0: "batch_size"}},
+        opset_version=opset,
+    )
+
+    onnx_model = onnx.load(output_path)
+    onnx.checker.check_model(onnx_model)
+    print(f"Exported ONNX model to {output_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Export image model to ONNX")
+    parser.add_argument("--weights", required=True, help="Path to trained .pth file")
+    parser.add_argument("--output", default="image_model.onnx", help="Output ONNX file")
+    parser.add_argument("--img-size", type=int, default=224, help="Image size used during training")
+    parser.add_argument("--opset-version", type=int, default=14, help="ONNX opset version")
+    args = parser.parse_args()
+    export_model(args.weights, args.output, args.img_size, args.opset_version)
+

--- a/ml/train_image_model.py
+++ b/ml/train_image_model.py
@@ -1,0 +1,95 @@
+import argparse
+import os
+import random
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, random_split
+from torchvision import datasets, transforms, models
+
+
+def load_dataloaders(dataset_path: str, img_size: int, batch_size: int):
+    transform = transforms.Compose([
+        transforms.Resize((img_size, img_size)),
+        transforms.ToTensor(),
+        transforms.Normalize(
+            mean=[0.485, 0.456, 0.406],
+            std=[0.229, 0.224, 0.225],
+        ),
+    ])
+
+    dataset = datasets.ImageFolder(dataset_path, transform=transform)
+    train_size = int(0.8 * len(dataset))
+    val_size = len(dataset) - train_size
+    generator = torch.Generator().manual_seed(42)
+    train_ds, val_ds = random_split(dataset, [train_size, val_size], generator=generator)
+
+    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
+    val_loader = DataLoader(val_ds, batch_size=batch_size, shuffle=False)
+    return train_loader, val_loader, len(dataset.classes)
+
+
+def train(args):
+    random.seed(42)
+    torch.manual_seed(42)
+
+    train_loader, val_loader, num_classes = load_dataloaders(
+        args.dataset_path, args.img_size, args.batch_size
+    )
+
+    model = models.resnet18(weights=models.ResNet18_Weights.DEFAULT)
+    model.fc = nn.Linear(model.fc.in_features, num_classes)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=3e-4)
+
+    best_acc = 0.0
+    best_state = None
+
+    for epoch in range(args.epochs):
+        model.train()
+        for images, labels in train_loader:
+            images, labels = images.to(device), labels.to(device)
+            optimizer.zero_grad()
+            outputs = model(images)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+        model.eval()
+        correct = 0
+        total = 0
+        with torch.no_grad():
+            for images, labels in val_loader:
+                images, labels = images.to(device), labels.to(device)
+                outputs = model(images)
+                preds = outputs.argmax(dim=1)
+                correct += (preds == labels).sum().item()
+                total += labels.size(0)
+        acc = correct / total if total else 0
+        print(f"Epoch {epoch+1}: val_accuracy={acc:.4f}")
+        if acc > best_acc:
+            best_acc = acc
+            best_state = model.state_dict()
+
+    if best_state is not None:
+        model.load_state_dict(best_state)
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    model_path = os.path.join(args.output_dir, "image_model.pth")
+    torch.save(model.state_dict(), model_path)
+    print(f"Model saved to {model_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Train image classification model")
+    parser.add_argument("--dataset-path", required=True, help="Path to image dataset")
+    parser.add_argument("--output-dir", default="./ml_models/image_model", help="Directory to save model")
+    parser.add_argument("--img-size", type=int, default=224, help="Input image size")
+    parser.add_argument("--batch-size", type=int, default=32, help="Batch size")
+    parser.add_argument("--epochs", type=int, default=3, help="Number of training epochs")
+    args = parser.parse_args()
+    train(args)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,5 @@ typing_extensions==4.14.0
 tzdata==2025.2
 urllib3==2.5.0
 uvicorn==0.34.3
+Pillow==10.2.0
+torchvision==0.18.0


### PR DESCRIPTION
## Summary
- extend requirements with Pillow and torchvision
- add a training script for image classification
- support exporting trained image model to ONNX
- load the image model in the backend and add `/predict-image` endpoint
- document new scripts and endpoint usage

## Testing
- `python -m py_compile ml/train_image_model.py ml/export_image_to_onnx.py backend/app.py ml/train_model.py ml/export_to_onnx.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685af425270c8327bb9941f0f983e5bc