### PR TITLE
Add C2PA watermark check for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ curl -X POST http://localhost:8000/predict-image \
 
 The response contains the predicted label and confidence score.
 
+If the image includes C2PA metadata indicating that it was produced by DALL·E
+or ChatGPT, the API responds with `"AI-generated (watermark detected)"` without
+running the classifier.
+
 
 ## Team
 - Cheikh Ahmedou Enaha

--- a/backend/app.py
+++ b/backend/app.py
@@ -8,7 +8,7 @@ import os
 from PIL import Image
 import base64
 from io import BytesIO
-from watermark import detect_synthid, detect_stable_signature
+from watermark import detect_c2pa
 
 # Initialize FastAPI app
 app = FastAPI(
@@ -176,7 +176,7 @@ async def predict_image(file: UploadFile = File(None), image_base64: str = Form(
         raise HTTPException(status_code=400, detail="Invalid image file")
 
     # Check for embedded watermarks before running the model
-    if detect_synthid(img) or detect_stable_signature(img):
+    if detect_c2pa(img):
         return {"prediction": "AI-generated (watermark detected)"}
 
     img = img.resize((IMAGE_SIZE, IMAGE_SIZE))

--- a/backend/watermark.py
+++ b/backend/watermark.py
@@ -1,13 +1,55 @@
+from io import BytesIO
 from PIL import Image
 
+try:
+    from open_c2pa import ManifestStore
+except Exception:  # pragma: no cover - library may not be installed during tests
+    ManifestStore = None
 
-def detect_synthid(image: Image.Image) -> bool:
-    """Stub for Google SynthID watermark detection."""
-    # TODO: Replace with real detection logic
+
+def detect_c2pa(image: Image.Image) -> bool:
+    """Detect C2PA manifests mentioning DALL·E or ChatGPT.
+
+    Parameters
+    ----------
+    image: PIL.Image.Image
+        Image to inspect for embedded C2PA metadata.
+
+    Returns
+    -------
+    bool
+        ``True`` if a manifest referencing DALL·E or ChatGPT is found,
+        ``False`` otherwise.
+    """
+
+    if ManifestStore is None:
+        # Library not available; unable to detect
+        return False
+
+    try:
+        with BytesIO() as buf:
+            fmt = image.format or "PNG"
+            image.save(buf, format=fmt)
+            data = buf.getvalue()
+
+        store = ManifestStore.from_bytes(data)
+        if not store or not store.claim:
+            return False
+
+        claim = store.claim
+
+        generator = (getattr(claim, "generator", "") or "").lower()
+        if "dall" in generator or "chatgpt" in generator:
+            return True
+
+        for ingredient in getattr(claim, "ingredients", []):
+            title = (getattr(ingredient, "title", "") or "").lower()
+            if "dall" in title or "chatgpt" in title:
+                return True
+
+    except Exception:
+        # Any parsing errors imply no valid watermark detected
+        return False
+
     return False
 
-
-def detect_stable_signature(image: Image.Image) -> bool:
-    """Stub for Stability AI Stable Signature detection."""
-    # TODO: Replace with real detection logic
-    return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ urllib3==2.5.0
 uvicorn==0.34.3
 Pillow==10.2.0
 torchvision==0.18.0
+open-c2pa==0.2.6


### PR DESCRIPTION
## Summary
- replace SynthID & Stable Signature stubs with `detect_c2pa`
- use C2PA detection in `/predict-image`
- include `open-c2pa` in requirements
- document C2PA check in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bef3241608327a7a675476b33a1e7