### PR TITLE
Add shared config defaults and refactor ml scripts

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,8 @@
+import os
+
+DEFAULT_TEXT_MODEL_DIR = "ml_models/trained_model"
+DEFAULT_SMOGY_DIR = "models/smogy"
+DEFAULT_ONNX_PATH = "model.onnx"
+DEFAULT_REPO_ID = "Smogy/SMOGY-Ai-images-detector"
+DEFAULT_MODEL_NAME = "distilbert-base-uncased"
+DEFAULT_DATASET_PATH = os.getenv("DATA_PATH")

--- a/ml/download_smogy.py
+++ b/ml/download_smogy.py
@@ -1,17 +1,18 @@
 import argparse
 from huggingface_hub import snapshot_download
 import os
+from config import DEFAULT_REPO_ID, DEFAULT_SMOGY_DIR
 
 
 def main():
     parser = argparse.ArgumentParser(description="Download the Smogy model from Hugging Face")
     parser.add_argument(
         "--repo-id",
-        default="Smogy/SMOGY-Ai-images-detector",
+        default=DEFAULT_REPO_ID,
         help="Repository id on the Hugging Face Hub",
     )
     parser.add_argument(
-        "--output-dir", default="models/smogy", help="Directory to save the model"
+        "--output-dir", default=DEFAULT_SMOGY_DIR, help="Directory to save the model"
     )
     parser.add_argument("--revision", default=None, help="Optional revision")
     args = parser.parse_args()

--- a/ml/export_to_onnx.py
+++ b/ml/export_to_onnx.py
@@ -2,6 +2,7 @@ import argparse
 import torch
 import onnx
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
+from config import DEFAULT_TEXT_MODEL_DIR, DEFAULT_ONNX_PATH
 
 
 def export_model(model_dir: str, output_path: str, opset: int = 14, max_length: int = 256) -> None:
@@ -46,13 +47,13 @@ def main() -> None:
     # Now optional with a default value
     parser.add_argument(
         "--model-dir",
-        default="ml_models/trained_model",  # or your local default model path
+        default=DEFAULT_TEXT_MODEL_DIR,
         help="Path to the trained model directory (local or model name from Hugging Face hub)"
     )
 
     parser.add_argument(
         "--output-path",
-        default="model.onnx",
+        default=DEFAULT_ONNX_PATH,
         help="Where to save the exported ONNX model"
     )
 

--- a/ml/smogy_inference.py
+++ b/ml/smogy_inference.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 from transformers import AutoImageProcessor, AutoModelForImageClassification
+from config import DEFAULT_SMOGY_DIR
 from PIL import Image
 import torch
 import numpy as np
@@ -32,7 +33,7 @@ def main():
     parser = argparse.ArgumentParser(description="Run inference with the Smogy model")
     parser.add_argument("image", help="Path to an image")
     parser.add_argument(
-        "--model-dir", default="models/smogy", help="Directory containing the model"
+        "--model-dir", default=DEFAULT_SMOGY_DIR, help="Directory containing the model"
     )
     args = parser.parse_args()
 

--- a/ml/train_model.py
+++ b/ml/train_model.py
@@ -1,5 +1,10 @@
 import os
 import argparse
+from config import (
+    DEFAULT_DATASET_PATH,
+    DEFAULT_MODEL_NAME,
+    DEFAULT_TEXT_MODEL_DIR,
+)
 import random
 import pandas as pd
 import numpy as np
@@ -87,16 +92,18 @@ def compute_metrics(eval_pred):
 def main():
     parser = argparse.ArgumentParser(description="Train text classification model")
     parser.add_argument(
-        "--dataset-path", default=os.getenv("DATA_PATH"), help="Path to CSV dataset"
+        "--dataset-path",
+        default=DEFAULT_DATASET_PATH,
+        help="Path to CSV dataset",
     )
     parser.add_argument(
         "--model-name",
-        default="distilbert-base-uncased",
+        default=DEFAULT_MODEL_NAME,
         help="Pretrained model name",
     )
     parser.add_argument(
         "--output-dir",
-        default="./ml_models/trained_models",
+        default=DEFAULT_TEXT_MODEL_DIR,
         help="Directory to save model",
     )
     args = parser.parse_args()

--- a/ml/train_smogy.py
+++ b/ml/train_smogy.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+from config import DEFAULT_SMOGY_DIR
 from datasets import load_dataset
 from transformers import (
     AutoImageProcessor,
@@ -26,12 +27,12 @@ def main():
     )
     parser.add_argument(
         "--model-dir",
-        default="models/smogy",
+        default=DEFAULT_SMOGY_DIR,
         help="Path to pretrained model directory",
     )
     parser.add_argument(
         "--output-dir",
-        default="models/smogy",
+        default=DEFAULT_SMOGY_DIR,
         help="Where to save the fine-tuned model",
     )
     parser.add_argument("--epochs", type=int, default=3, help="Number of epochs")


### PR DESCRIPTION
## Summary
- centralize frequently used paths/constants in new `config.py`
- refactor ML scripts to use the config defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e80f211b483279964808aad6f4d45