### PR TITLE
Add dataset slice options for Smogy training

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,12 @@ expects a dataset in the `imagefolder` format with `train` and optional
 ```bash
 python ml/train_smogy.py \
   --dataset-path path/to/images \
-  --output-dir ./models/smogy
+  --output-dir ./models/smogy \
+  --train-size 1000  # optional
 ```
+
+Use `--train-size` and `--val-size` to limit the number of training and
+validation samples if you want to train on only a portion of the dataset.
 
 ## Exporting the Model to ONNX
 

--- a/ml/train_smogy.py
+++ b/ml/train_smogy.py
@@ -38,9 +38,28 @@ def main():
     )
     parser.add_argument("--epochs", type=int, default=3, help="Number of epochs")
     parser.add_argument("--batch-size", type=int, default=8, help="Batch size")
+    parser.add_argument(
+        "--train-size",
+        type=int,
+        default=None,
+        help="Number of training samples to use",
+    )
+    parser.add_argument(
+        "--val-size",
+        type=int,
+        default=None,
+        help="Number of validation samples to use",
+    )
     args = parser.parse_args()
 
     dataset = load_dataset("imagefolder", data_dir=args.dataset_path)
+
+    if args.train_size is not None:
+        train_count = min(args.train_size, len(dataset["train"]))
+        dataset["train"] = dataset["train"].shuffle(seed=42).select(range(train_count))
+    if args.val_size is not None and "validation" in dataset:
+        val_count = min(args.val_size, len(dataset["validation"]))
+        dataset["validation"] = dataset["validation"].shuffle(seed=42).select(range(val_count))
 
     processor = AutoImageProcessor.from_pretrained(args.model_dir)
     model = AutoModelForImageClassification.from_pretrained(args.model_dir)


### PR DESCRIPTION
## Summary
- allow training `ml/train_smogy.py` on a subset of the dataset
- document new `--train-size` and `--val-size` options in README

## Testing
- `pre-commit` *(fails: no hooks installed)*

------
https://chatgpt.com/codex/tasks/task_e_685f10c248b48327a975538effe10d0f