### PR TITLE
Prevent model overwrite during training

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,13 @@ arguments or environment variables.
 python ml/train_model.py \
   --dataset-path path/to/AI_Human.csv \
   --model-name distilbert-base-uncased \
-  --output-dir ./ml_models/trained_model
+  --output-dir ./ml_models/trained_models
 ```
 
 The script expects a CSV file with a `text` column and a `label` column
-(alternatively `generated` or `is_ai_generated`). The trained model and
-tokenizer will be saved to the directory specified by `--output-dir`.
+(alternatively `generated` or `is_ai_generated`). A new subdirectory named
+`run_YYYYMMDD_HHMMSS` will be created inside the specified `--output-dir` and
+the trained model along with its tokenizer will be saved there.
 You can also pass `--save-train-texts train_texts.csv` to store the texts used
 for fine-tuning. Later, use this file with the `--exclude-path` option when
 evaluating to avoid overlap.
@@ -113,7 +114,7 @@ also appear in your training/validation data.
 ```bash
 python ml/evaluate_model.py \
   --dataset-path test.csv \
-  --model-dir ./ml_models/trained_model \
+  --model-dir ./ml_models/trained_models/run_YYYYMMDD_HHMMSS \
   --exclude-path train_texts.csv \
   --sample-size 0.2  # evaluate on 20% of the test set
 ```
@@ -143,7 +144,7 @@ After training you can export the model to ONNX format using `ml/export_to_onnx.
 
 ```bash
 python ml/export_to_onnx.py \
-  --model-dir ./ml_models/trained_model \
+  --model-dir ./ml_models/trained_models/run_YYYYMMDD_HHMMSS \
   --output-path ./ml_models/model.onnx
 ```
 

--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
 import os
 
-DEFAULT_TRAINED_MODELS_DIR = "ml_models/trained_model"
+DEFAULT_TRAINED_MODELS_DIR = "ml_models/trained_models"
 DEFAULT_SMOGY_DIR = "models/smogy"
 DEFAULT_DISTILBERT_DOWNLOAD_DIR = "models/roberta-base"
 DEFAULT_ONNX_PATH = "/home/emin/Documents/Projects/ProjetAuthenti/authenti-score-forked/ml_models/onnx"

--- a/ml/train_model.py
+++ b/ml/train_model.py
@@ -5,8 +5,9 @@ from config import (
     DEFAULT_MODEL_ID,
     DEFAULT_TRAINED_MODELS_DIR,
     DEFAULT_DISTILBERT_DOWNLOAD_DIR,
-    USED_DATASET_PATH
+    USED_DATASET_PATH,
 )
+from datetime import datetime
 import random
 import pandas as pd
 import numpy as np
@@ -120,7 +121,6 @@ def main():
     )
     parser.add_argument(
         "--save-train-texts",
-        default=None,
         default=USED_DATASET_PATH,
         help=(
             "Optional path to write a CSV with the texts used for"
@@ -216,10 +216,12 @@ def main():
     # -----------------------------------------------------------------------
     # Save artefacts
     # -----------------------------------------------------------------------
-    os.makedirs(args.output_dir, exist_ok=True)
-    trainer.save_model(args.output_dir)
-    tokenizer.save_pretrained(args.output_dir)
-    print(f"Model and tokenizer saved to {args.output_dir}")
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    final_output_dir = os.path.join(args.output_dir, f"run_{timestamp}")
+    os.makedirs(final_output_dir, exist_ok=True)
+    trainer.save_model(final_output_dir)
+    tokenizer.save_pretrained(final_output_dir)
+    print(f"Model and tokenizer saved to {final_output_dir}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- avoid duplicate defaults in `train_model.py`
- save models to timestamped directories
- document the new training output layout
- store trained models in `trained_models` directory

## Testing
- `python -m py_compile ml/train_model.py ml/train_smogy.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_6860433365788327b88b11e073d82561