### PR TITLE
Add MLflow tracking support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ python ml/evaluate_model.py \
 The `--sample-size` option accepts either a fraction (between 0 and 1) or an
 integer number of samples to evaluate.
 
+## Tracking with MLflow
+
+Install `mlflow` from the requirements and run a local tracking server:
+
+```bash
+mlflow server --backend-store-uri ./mlruns --default-artifact-root ./mlruns -p 5000
+```
+
+The training and evaluation scripts will by default log to `http://localhost:5000`.
+Start the server and then run the scripts:
+
+```bash
+python ml/train_model.py --dataset-path train.csv --mlflow-experiment my-exp
+python ml/evaluate_model.py --dataset-path test.csv --model-dir ./ml_models/run_xxx \
+  --mlflow-experiment my-exp
+```
+
 ## Training the Image Model
 
 Use `ml/train_smogy.py` to fine-tune the Smogy image classifier. The script

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,4 @@ torchvision==0.18.0
 open-c2pa==0.2.6
 scikit-learn
 evaluate
+mlflow


### PR DESCRIPTION
## Summary
- add `mlflow` dependency
- integrate MLflow logging into training and evaluation scripts
- allow tracking Smogy image training with MLflow
- document running a local MLflow server
- default MLflow URI to local server

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860475e4a6c8327a6ea3a8f80a7b2a1